### PR TITLE
Fix 'missing assets/data/' build error and gitignore for .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,7 +476,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
@@ -653,5 +653,5 @@ packages:
     source: hosted
     version: "0.1.2"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.10.0-110 <=2.11.0-186.0.dev"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,4 +30,3 @@ flutter:
 
   assets:
     - assets/images/
-    - assets/data/


### PR DESCRIPTION
Minor tweaks... 

Fixes this error when running `build web`:

```
Error: unable to find directory entry in pubspec.yaml: /home/jelavallee/workspace/sandbox/dc-dev-community/assets/data/
```

Guessing it's just a left-over from when you moved the content JSON over to firebase.

Also, a housekeeping gitignore to make sure .vscode settings don't get pushed.

Flutter version info:

```
Flutter 1.23.0-13.0.pre • channel dev • https://github.com/flutter/flutter.git
Framework • revision 4fa4f91d5c (7 days ago) • 2020-10-06 12:31:25 -0700
Engine • revision 443cd5a1e1
Tools • Dart 2.11.0 (build 2.11.0-186.0.dev)```